### PR TITLE
Refactor site with Jekyll layout and shared navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+title: "Souvik Datta"

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,14 @@
+<p style="text-align:center">
+  <name>Souvik Datta</name>
+</p>
+<p style="text-align:center">
+  <a href="mailto:souvikdatta123@gmail.com">Email</a> &nbsp/&nbsp
+  <a href="data/CV_Souvik_Datta.pdf">CV</a> &nbsp/&nbsp
+  <a href="https://github.com/souvik0306">GitHub</a> &nbsp/&nbsp
+  <a href="https://scholar.google.com/citations?user=DCqpUvMAAAAJ&hl=en">Google Scholar</a> &nbsp/&nbsp
+  <a href="https://www.linkedin.com/in/souvik-datta03/">LinkedIn</a> &nbsp/&nbsp
+  <a href="{{ '/index.html' | relative_url }}">Home</a> &nbsp/&nbsp
+  <a href="{{ '/personal.html' | relative_url }}">Personal</a> &nbsp/&nbsp
+  <a href="{{ '/aviation.html' | relative_url }}">Aviation</a> &nbsp/&nbsp
+  <a href="{{ '/slideshow.html' | relative_url }}">Slideshow</a>
+</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NMPKHLN7DN"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-NMPKHLN7DN');
+  </script>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>{{ page.title | default: site.title }}</title>
+  <meta name="author" content="Souvik Datta">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" type="text/css" href="{{ '/stylesheet.css' | relative_url }}">
+  <link rel="icon" type="image/png" href="{{ '/images/avatar.png' | relative_url }}">
+  {% if page.extra_head %}
+  {{ page.extra_head }}
+  {% endif %}
+</head>
+<body{% if page.body_class %} class="{{ page.body_class }}"{% endif %}>
+  {{ content }}
+</body>
+</html>

--- a/aviation.html
+++ b/aviation.html
@@ -1,46 +1,14 @@
-
-<!DOCTYPE HTML>
-<html lang="en"><head>
-  <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NMPKHLN7DN"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-NMPKHLN7DN');
-</script>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-
-  <title>Souvik Datta</title>
-
-  <meta name="author" content="Souvik Datta">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  
-  <link rel="stylesheet" type="text/css" href="stylesheet.css">
-  <link rel="icon" type="image/png" href="images/avatar.png">
-</head>
-
-<body>
+---
+layout: default
+title: Souvik Datta
+---
   <table style="width:100%;max-width:800px;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
     <tr style="padding:0px">
       <td style="padding:0px">
         <table style="width:110%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
           <tr style="padding:0px">
             <td style="padding:2.5%;width:63%;vertical-align:middle">
-              <p style="text-align:center">
-                <name>Souvik Datta</name>
-
-              <p style="text-align:center">
-                <a href="mailto:souvikdatta123@gmail.com">Email</a> &nbsp/&nbsp
-                <a href="data/CV_Souvik_Datta.pdf">CV</a> &nbsp/&nbsp
-                <a href="https://github.com/souvik0306">GitHub</a> &nbsp/&nbsp
-                <a href="https://scholar.google.com/citations?user=DCqpUvMAAAAJ&hl=en">Google Scholar</a> &nbsp/&nbsp
-                <a href="https://www.linkedin.com/in/souvik-datta03/">LinkedIn</a>  &nbsp/&nbsp
-                <a href="index.html">Home Page</a> &nbsp/&nbsp
-                <a href="personal.html">Personal Page</a>
-
-              </p>
+              {% include nav.html %}
 
               <b><p style="text-align:center">A day without discussing aircrafts is a day squandered :)</p></b>
               <p style="text-align:justify">As an aviation enthusiast, I'm not afraid to admit that I'm a "Boeing Fan". There's just something about the aircraft manufacturer that gets my adrenaline pumping and my heart racing.</p></b>
@@ -93,6 +61,3 @@
       </td>
     </tr>
   </table>
-</body>
-
-</html>

--- a/index.html
+++ b/index.html
@@ -1,35 +1,14 @@
-
-<!DOCTYPE HTML>
-<html lang="en"><head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NMPKHLN7DN"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-  
-    gtag('config', 'G-NMPKHLN7DN');
-  </script><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-
-  <title>Souvik Datta</title>
-
-  <meta name="author" content="Souvik Datta">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  
-  <link rel="stylesheet" type="text/css" href="stylesheet.css">
-  <link rel="icon" type="image/png" href="images/avatar.png">
-</head>
-
-<body>
+---
+layout: default
+title: Souvik Datta
+---
   <table style="width:100%;max-width:900px;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
     <tr style="padding:0px">
       <td style="padding:0px">
         <table style="width:100%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;"><tbody>
           <tr style="padding:0px">
             <td style="padding:2.5%;width:63%;vertical-align:middle">
-              <p style="text-align:center">
-                <name>Souvik Datta</name>
-              </p>
+              {% include nav.html %}
                 <p style="text-align:justify">I am a Graduate student in Electrical Engineering at the National University of Singapore. I hold a B.Tech in Electrical and Electronics Engineering from Vellore Institute of Technology, Chennai, and have previously worked as a Software Developer at QBlocks.
               </p>
 
@@ -45,15 +24,6 @@
                 I am excited about the future and look forward to contributing to amazing projects in AI, Robotics, and Aviation. If you share similar interests or have a project in mind, let's connect and explore the possibilities together.
                 </p>
 
-              <p style="text-align:center">
-                <a href="mailto:souvikdatta123@gmail.com">Email</a> &nbsp/&nbsp
-                <a href="data/Souvik Datta Resume.pdf">CV</a> &nbsp/&nbsp
-                <a href="https://github.com/souvik0306">GitHub</a> &nbsp/&nbsp
-                <a href="https://scholar.google.com/citations?user=DCqpUvMAAAAJ&hl=en">Google Scholar</a> &nbsp/&nbsp
-                <a href="https://www.linkedin.com/in/souvik-datta03/">LinkedIn</a> &nbsp/&nbsp
-                <a href="personal.html">Personal Life</a>
-
-              </p>
             </td>
             <td style="padding:2.5%;width:40%;max-width:60%">
               <a href="images/Profile Pic.JPG"><img style="width:135%;max-width:220%" alt="profile photo" src="images/Profile Pic.JPG" class="hoverZoomLink"></a>
@@ -171,6 +141,3 @@
       </td>
     </tr>
   </table>
-</body>
-
-</html>

--- a/personal.html
+++ b/personal.html
@@ -1,24 +1,8 @@
-
-<!DOCTYPE HTML>
-<html lang="en"><head>
-  <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NMPKHLN7DN"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-NMPKHLN7DN');
-</script>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>Souvik Datta</title>
-  
-  <meta name="author" content="Souvik Datta">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  
-  <link rel="stylesheet" type="text/css" href="stylesheet.css">
-  <link rel="icon" type="image/png" href="images/avatar.png">
-  
+---
+layout: default
+title: Souvik Datta
+body_class: w-11/12 m-auto mt-6
+extra_head: |
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <style>
     /* Custom styles for hover effects */
@@ -29,33 +13,16 @@
       transform: translateY(0);
     }
     a {
-      color: blue; /* Set the color to blue */
-      text-decoration: none; /* Remove default underline */
+      color: blue;
+      text-decoration: none;
     }
-    /* Define the hover effect for the links */
     a:hover {
-      text-decoration: underline; /* Underline the link on hover */
+      text-decoration: underline;
     }
-    
   </style>
-</head>
+---
+{% include nav.html %}
 
-<body class="w-11/12 m-auto mt-6">
-
-  <div>
-    <p style="text-align:center">
-      <name>Souvik Datta</name>
-
-      <p style="text-align:center">
-        <a href="mailto:souvikdatta123@gmail.com">Email</a> &nbsp/&nbsp
-        <a href="data/CV_Souvik_Datta.pdf">CV</a> &nbsp/&nbsp
-        <a href="https://github.com/souvik0306">GitHub</a> &nbsp/&nbsp
-        <a href="https://scholar.google.com/citations?user=DCqpUvMAAAAJ&hl=en">Google Scholar</a> &nbsp/&nbsp
-        <a href="https://www.linkedin.com/in/souvik-datta03/">LinkedIn</a>  &nbsp/&nbsp
-        <a href="index.html">Home Page</a> &nbsp/&nbsp
-        <a href="aviation.html">Aviation Page</a>
-      </p>
-  </div>
 
   <div style="margin-top: 20px;"> <!-- Increased margin-top for vertical spacing -->
     <p style="text-align:center">
@@ -132,6 +99,3 @@
       </a>
     </div>
   </div>
-</body>
-
-</html>

--- a/slideshow.html
+++ b/slideshow.html
@@ -1,27 +1,7 @@
-<!DOCTYPE HTML>
-<html lang="en">
-<head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NMPKHLN7DN"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-NMPKHLN7DN');
-  </script>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-
-  <title>Souvik Datta</title>
-
-  <meta name="author" content="Souvik Datta">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  
-  <link rel="stylesheet" type="text/css" href="stylesheet.css">
-  <link rel="icon" type="image/png" href="images/avatar.png">
-</head>
-
-<body>
+---
+layout: default
+title: Souvik Datta
+---
   <table style="width:100%;max-width:800px;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;">
     <tbody>
       <tr style="padding:0px">
@@ -30,19 +10,7 @@
             <tbody>
               <tr style="padding:0px">
                 <td style="padding:2.5%;width:63%;vertical-align:middle">
-                  <p style="text-align:center">
-                    <h1>Souvik Datta</h1>
-                  </p>
-
-                  <p style="text-align:center">
-                    <a href="mailto:souvikdatta123@gmail.com">Email</a> &nbsp;/&nbsp;
-                    <a href="data/CV_Souvik_Datta.pdf">CV</a> &nbsp;/&nbsp;
-                    <a href="https://github.com/souvik0306">GitHub</a> &nbsp;/&nbsp;
-                    <a href="https://scholar.google.com/citations?user=DCqpUvMAAAAJ&hl=en">Google Scholar</a> &nbsp;/&nbsp;
-                    <a href="https://www.linkedin.com/in/souvik-datta03/">LinkedIn</a>  &nbsp;/&nbsp;
-                    <a href="index.html">Home Page</a> &nbsp;/&nbsp;
-                    <a href="aviation.html">Aviation Page</a>
-                  </p>
+                    {% include nav.html %}
                 </td>
               </tr>
             </tbody>
@@ -68,5 +36,3 @@
   </div>
 
   <script src="script.js"></script>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- add a Jekyll layout that centralizes metadata and shared resources
- introduce a reusable navigation include and migrate pages to Jekyll front matter
- convert existing HTML pages to use the shared layout and navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c8302ab0832c81fa3e60f4111483